### PR TITLE
code update for Matlab R2022a or later

### DIFF
--- a/src/redisCommandString.m
+++ b/src/redisCommandString.m
@@ -9,7 +9,6 @@ cmd = sprintf('*%d', n_words);
 for ix = 1 : n_words
   word = words{ix};
   word_length = numel(word);
-  cmd = sprintf('%s\n$%d\n%s', cmd, word_length, word);
+  cmd = sprintf('%s\r\n$%d\r\n%s', cmd, word_length, word);
 end
-
 % note the final \r\n is added by the port

--- a/src/redisConnection.m
+++ b/src/redisConnection.m
@@ -8,8 +8,8 @@ if nargin < 2,
   port = 6379;
 end
 
-r = tcpip(host, port);
-r.terminator = 'CR/LF';
+r = tcpclient(host, port);
+r.configureTerminator('CR/LF');
 fopen(r);
 
 if ~strcmp(r.Status, 'open')

--- a/src/redisDisconnect.m
+++ b/src/redisDisconnect.m
@@ -1,3 +1,3 @@
 function R = redisDisconnect(R)
 
-fclose(R);
+delete(R);

--- a/src/redisHGet.m
+++ b/src/redisHGet.m
@@ -3,7 +3,7 @@ function [V, R, S] = redisHGet(R, key, field)
 S = 'OK';
 V = [];
 
-if ~strcmp(R.status, 'open')
+if ~strcmp(R.Status, 'open')
   S = 'ERROR - NO CONNECTION';
   return
 end

--- a/src/redisHGetAll.m
+++ b/src/redisHGetAll.m
@@ -4,7 +4,7 @@ S = 'OK';
 Fields = {};
 Values = {};
 
-if ~strcmp(R.status, 'open')
+if ~strcmp(R.Status, 'open')
   S = 'ERROR - NO CONNECTION';
   return;
 end

--- a/src/redisHMSet.m
+++ b/src/redisHMSet.m
@@ -7,7 +7,7 @@ if ~iscell(fields) || ~iscell(values) || numel(fields) ~= numel(values)
   return
 end
 
-if ~strcmp(R.status, 'open')
+if ~strcmp(R.Status, 'open')
   S = 'ERROR - NO CONNECTION';
   return
 end

--- a/src/redisHSet.m
+++ b/src/redisHSet.m
@@ -7,7 +7,7 @@ if ~isstr(value)
   return
 end
 
-if ~strcmp(R.status, 'open')
+if ~strcmp(R.Status, 'open')
   S = 'ERROR - NO CONNECTION';
   return
 end

--- a/src/redisPing.m
+++ b/src/redisPing.m
@@ -2,7 +2,7 @@ function [Value, R, S] = redisPing(R)
 
 S = 'OK';
 Value = [];
-
+fopen(R);
 if ~strcmp(R.Status, 'open')
   S = 'ERROR - NO CONNECTION';
   return;

--- a/src/redisSelect.m
+++ b/src/redisSelect.m
@@ -1,0 +1,15 @@
+function [R, S] = redisSelect(R, db)
+
+S = 'OK';
+Value = [];
+fopen(R);
+if ~strcmp(R.Status, 'open')
+  S = 'ERROR - NO CONNECTION';
+  return;
+end
+
+[Response, R, S] = redisCommand(R, redisCommandString(sprintf('SELECT %d', db)));
+
+Response = strtrim(Response);
+
+

--- a/src/redisSet.m
+++ b/src/redisSet.m
@@ -7,7 +7,9 @@ if ~isstr(value)
   return
 end
 
-if ~strcmp(R.status, 'open')
+%fopen(R);
+
+if ~strcmp(R.Status, 'open')
   S = 'ERROR - NO CONNECTION';
   return
 end

--- a/test/test.m
+++ b/test/test.m
@@ -10,6 +10,8 @@ assert_string(M, 'OK');
 [Value, R, M] = redisPing(R);
 assert_string(Value, 'PONG');
 
+[R, M] = redisSelect(R, 0);  % select 0
+
 [R, M] = redisSet(R, 'foo', 'bar');
 assert_string(M, 'OK');
 
@@ -24,9 +26,18 @@ assert_string(Value, 'bar');
 S = redisGet(R, 'foo');
 assert_string(Value, 'bar');
 
-redisDisconnect(R);
+[R, M] = redisHSet(R, 'foo1', 'aa', '1234');
+[R, M] = redisHSet(R, 'foo1', 'bb', 'bb1234');
+assert_string(M, 'OK');
 
-assert_string(R.status, 'closed');
+[Value, R, M] = redisHGet(R, 'foo1','aa');
+assert_string(M, 'OK');
+assert_string(Value, '1234');
+
+[Value, R, M] = redisHGetAll(R, 'foo1');
+disp(Value)
+
+redisDisconnect(R);
 
 disp('All tests passed!')
 


### PR DESCRIPTION
- 'tcpip' is replaced by 'tcpclient' and 'tcpserver' from matlab r2022a or later. 
- I updated the code to handle this changes.
- Add db selection functionality (redisSelect.m)