### PR TITLE
bug fix : reading values greater than 512 bytes

### DIFF
--- a/src/redisCommand.m
+++ b/src/redisCommand.m
@@ -5,7 +5,7 @@ fprintf(R, Cmd);
 % wait for bytes to show up
 timeout = 1.0;
 tic
-while R.BytesAvailable == 0,
+while R.NumBytesAvailable == 0,
   pause(0.005)
   if toc >= timeout
     Output = '';
@@ -13,10 +13,10 @@ while R.BytesAvailable == 0,
     return;
   end
 end
-
+R.InputBufferSize = R.NumBytesAvailable+1;
 response = '';
 tic
-while R.BytesAvailable > 0,
+while R.NumBytesAvailable > 0,
   [chunk, ~, msg] = fread(R, R.BytesAvailable);
   response = [response char(chunk')];
   if toc >= timeout


### PR DESCRIPTION
Due to the default input buffer size of fread in Matlab being 512 bytes, it cannot read values exceeding this limit. 
 This issue was resolved by adjusting the InputBufferSize. 